### PR TITLE
Add progress bars to the simulation cards

### DIFF
--- a/src/components/SimulationCard.vue
+++ b/src/components/SimulationCard.vue
@@ -8,6 +8,11 @@
       </div>
     </v-card-title>
     <v-divider />
+    <v-progress-linear
+      :indeterminate="indeterminate"
+      :color="progressColor"
+      :value="100"
+    />
     <v-card-text class="pa-0">
       <v-list
         class="pa-0"
@@ -135,6 +140,17 @@ export default {
     simulation: {
       type: Object,
       required: true,
+    },
+  },
+  computed: {
+    indeterminate() {
+      return !this.simulation.nli.complete;
+    },
+    progressColor() {
+      if (this.simulation.nli.complete) {
+        return 'green';
+      }
+      return 'primary';
     },
   },
   methods: {

--- a/src/components/SimulationCard.vue
+++ b/src/components/SimulationCard.vue
@@ -13,6 +13,29 @@
       :color="progressColor"
       :value="100"
     />
+    <v-alert
+      class="ma-0 sim-card-alert"
+      color="error"
+      dense
+      icon="mdi-alert-rhombus"
+      prominent
+      tile
+      type="error"
+    >
+      <v-row align="center">
+        <v-col class="grow">
+          An error has occured
+        </v-col>
+        <v-col class="shrink">
+          <v-btn
+            outlined
+            small
+          >
+            Learn More
+          </v-btn>
+        </v-col>
+      </v-row>
+    </v-alert>
     <v-card-text class="pa-0">
       <v-list
         class="pa-0"
@@ -101,20 +124,29 @@
       </v-tooltip>
       <v-tooltip top>
         <template v-slot:activator="{ on }">
-          <v-btn
-            icon
-            small
-            text
-            v-on="on"
-            @click="archiveSimulation(simulation._id)"
-          >
-            <v-icon
-              color="error"
-              size="20"
+          <v-hover v-slot:default="{ hover }">
+            <v-btn
+              icon
+              small
+              text
+              v-on="on"
+              @click="archiveSimulation(simulation._id)"
             >
-              mdi-archive
-            </v-icon>
-          </v-btn>
+              <v-icon
+                v-if="hover"
+                color="error"
+                size="20"
+              >
+                mdi-archive
+              </v-icon>
+              <v-icon
+                v-else
+                size="20"
+              >
+                mdi-archive
+              </v-icon>
+            </v-btn>
+          </v-hover>
         </template>
         <span>
           Archive
@@ -176,3 +208,13 @@ export default {
   },
 };
 </script>
+
+<style>
+.sim-card-alert .v-alert__icon {
+  font-size: 26px !important;
+  margin-right: 5px;
+}
+.sim-card-alert .v-alert__icon:after {
+  display: none;
+}
+</style>

--- a/src/components/SimulationCard.vue
+++ b/src/components/SimulationCard.vue
@@ -21,6 +21,7 @@
       prominent
       tile
       type="error"
+      :value="false"
     >
       <v-row align="center">
         <v-col class="grow">

--- a/src/pages/SimulationListPage.vue
+++ b/src/pages/SimulationListPage.vue
@@ -38,6 +38,7 @@
     </v-app-bar>
     <v-tabs-items
       :value="currentTab"
+      class="transparent"
       @change="setTabByIndex($event)"
     >
       <v-tab-item


### PR DESCRIPTION
@jtomeck This is my attempt at progress bars.  The API isn't quite complete, but eventually I will be able to do live updates for non-indeterminate progress.  There will also be a failure state, which I was planning on just making a red bar.  Let me know if you have any ideas to make this look better.

There will also be a need (probably) to show a similar progress bar in the simulation viewer component (https://github.com/NutritionalLungImmunity/lung-fungal-web/blob/master/src/components/SimulationViewer.vue), but that page probably requires a more thorough  redesign anyway.  I might start by just copying the status bar from the cards and make it float somewhere over the simulation.
