### PR TITLE
Fix initial load into simulation viewer

### DIFF
--- a/src/pages/SimulationListPage.vue
+++ b/src/pages/SimulationListPage.vue
@@ -1,5 +1,8 @@
 <template>
-  <v-main class="px-0">
+  <v-main
+    v-if="loaded"
+    class="px-0"
+  >
     <v-app-bar
       color="grey darken-3"
       dark
@@ -96,6 +99,7 @@ export default {
   },
   data() {
     return {
+      loaded: false,
       simulationCache: {},
     };
   },
@@ -112,10 +116,9 @@ export default {
       ).filter((tab) => tab !== undefined);
     },
   },
-  created() {
-    this.tabs.forEach((tab) => {
-      this.fetchSimulation(tab);
-    });
+  async created() {
+    await Promise.all(this.tabs.map((tab) => this.fetchSimulation(tab)));
+    this.loaded = true;
   },
   methods: {
     viewSimulation(simulation) {


### PR DESCRIPTION
When the simulation object is not precached the tab index is automatically reset back to the list page.  This change populates the cache before mounting the page.