### PR TITLE
Add support for showing units in config panel

### DIFF
--- a/src/components/ConfigGroup.vue
+++ b/src/components/ConfigGroup.vue
@@ -16,6 +16,7 @@
           :max="option.max"
           :step="option.step"
           :color="color"
+          :units="option.units || null"
           @input="onChange(option.id, $event)"
         />
       </div>

--- a/src/components/ConfigOption.vue
+++ b/src/components/ConfigOption.vue
@@ -7,8 +7,10 @@
         cols="12"
         class="py-0"
       >
-        <v-subheader class="panel-subheader pl-0">
-          {{ label }}
+        <v-subheader
+          class="panel-subheader pl-0"
+        >
+          {{ labelWithUnits }}
         </v-subheader>
         <v-slider
           :color="color"
@@ -27,7 +29,8 @@
               v-model="value"
               class="mt-0 pt-0"
               type="number"
-              style="width: 60px"
+              style="width: 72px"
+              :title="tooltip"
               dense
               hide-details
               outlined
@@ -93,6 +96,19 @@ export default {
     color: {
       type: String,
       required: true,
+    },
+    units: {
+      type: String,
+      required: false,
+      default: null,
+    },
+  },
+  computed: {
+    labelWithUnits() {
+      if (this.units) {
+        return `${this.label} (${this.units})`;
+      }
+      return this.label;
     },
   },
 };

--- a/src/config.js
+++ b/src/config.js
@@ -240,6 +240,7 @@ export default {
         default: 2,
         label: 'Duration of growth stage',
         help: 'Duration of growth stage in minutes',
+        units: 'minutes',
       }, {
         id: 'rest_time',
         min: 1,
@@ -248,6 +249,7 @@ export default {
         default: 2,
         label: 'Duration of resting stage',
         help: 'Duration of resting stage in minutes',
+        units: 'minutes',
       }, {
         id: 'swell_time',
         min: 1,
@@ -256,6 +258,7 @@ export default {
         default: 5,
         label: 'Duration of swollen stage',
         help: 'Duration of swollen stage in minutes',
+        units: 'minutes',
       }],
       epithelium: [{
         id: 'e_kill',
@@ -349,6 +352,7 @@ export default {
         default: 50,
         label: 'Simulation world time',
         help: 'Simulation world time (hours) as opposed to real world time',
+        units: 'hours',
       }, {
         id: 'validate',
         type: 'checkbox',


### PR DESCRIPTION
For now, the units are just displayed in parenthesis next to the label.  We may want to do something different in the future.

I added units to properties where they were given in the description.  I would only be guessing for the rest of them.

Fixes #77