### PR TITLE
Show a login button in place of run simulation

### DIFF
--- a/src/components/LoginDialog.vue
+++ b/src/components/LoginDialog.vue
@@ -14,22 +14,24 @@
         >
           <v-btn
             class="mx-1"
-            icon
+            :icon="icon"
             dark
             color="primary"
             v-bind="attrs"
             v-on="{ ...on, ...on_t }"
           >
-            <v-icon
-              v-if="!loggedIn"
-            >
-              mdi-login
-            </v-icon>
-            <v-icon
-              v-else
-            >
-              mdi-account-circle
-            </v-icon>
+            <slot>
+              <v-icon
+                v-if="!loggedIn"
+              >
+                mdi-login
+              </v-icon>
+              <v-icon
+                v-else
+              >
+                mdi-account-circle
+              </v-icon>
+            </slot>
           </v-btn>
         </template>
         <span>Login</span>
@@ -68,6 +70,13 @@ export default {
   inject: ['girderRest'],
   components: {
     GirderAuthentication,
+  },
+  props: {
+    icon: {
+      type: Boolean,
+      required: false,
+      default: true,
+    },
   },
   data() {
     return {

--- a/src/pages/ConfigPage.vue
+++ b/src/pages/ConfigPage.vue
@@ -29,7 +29,14 @@
           color="grey darken-4"
         >
           <v-spacer />
+          <login-dialog
+            v-if="girderRest.user === null"
+            :icon="false"
+          >
+            Login to run
+          </login-dialog>
           <config-dialog
+            v-else
             :config="values"
             @create="onCreate"
           />
@@ -43,6 +50,7 @@
 import ConfigDialog from '@/components/ConfigDialog.vue';
 import ConfigPanel from '@/components/ConfigPanel.vue';
 import Geometry from '@/components/Geometry.vue';
+import LoginDialog from '@/components/LoginDialog.vue';
 import State from '@/data/state';
 import config from '@/config';
 import cache from '@/cache';
@@ -55,6 +63,7 @@ export default {
     ConfigDialog,
     ConfigPanel,
     Geometry,
+    LoginDialog,
   },
   inject: ['girderRest'],
   props: {


### PR DESCRIPTION
This is to address the confusion in #75.  Rather than just displaying a disabled button when logged out, there will instead be a button the brings up the login dialog.

![login-to-run](https://user-images.githubusercontent.com/31890/108400962-d0d6f880-71e9-11eb-93cf-e57d61f131e1.png)
