### PR TITLE
it is possible that we may exceed 999 time steps in some models

### DIFF
--- a/src/data/simulation.js
+++ b/src/data/simulation.js
@@ -14,7 +14,7 @@ class Simulation {
         parentType: 'folder',
         parentId: this.id,
       },
-    })).data.filter((f) => /\d{3}/.test(f.name));
+    })).data.filter((f) => /\d/.test(f.name));
 
     this.totalTimeSteps = folders.length;
     const timeStepIds = [];


### PR DESCRIPTION
If we do a model where the base time step is 2 minutes (Henrique's model) and you simulate for 48 hours, this brings us to 1440 time steps. To be on the safe side, we need at least one more digits in the folder filenames. 

Regex changed to allow arbitrary numbers of digits. 