### PR TITLE
Load all timesteps associated with a simulation

### DIFF
--- a/src/data/simulation.js
+++ b/src/data/simulation.js
@@ -13,6 +13,7 @@ class Simulation {
       params: {
         parentType: 'folder',
         parentId: this.id,
+        limit: 0,
       },
     })).data.filter((f) => /\d/.test(f.name));
 


### PR DESCRIPTION
Girder has a default limit of 50.  By setting this to 0, we get all of them.  We might consider doing client side pagination here, but we will reach problems with the total volume of data we are loading on the client long before this rest call becomes an issue.