### PR TITLE
Run CI with a more stable version of Node

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:latest
+      - image: cimg/node:16.13
     steps:
       - checkout
       - run:


### PR DESCRIPTION
This should prevent errors with older Webpack versions and Node 17: https://stackoverflow.com/a/69637053

Also, use the newer- generation CircleCI images: https://circleci.com/blog/announcing-our-next-generation-convenience-images-smaller-faster-more-deterministic/